### PR TITLE
ModelDSL: don’t pass excluded attributes to builder

### DIFF
--- a/lib/rom/mapper/model_dsl.rb
+++ b/lib/rom/mapper/model_dsl.rb
@@ -48,7 +48,10 @@ module ROM
       # @api private
       def build_class
         return klass if klass
-        return builder.call(attributes.map(&:first)) if builder
+        included_attrs = attributes.reject do |_name, opts|
+          opts && opts[:exclude]
+        end
+        builder.call(included_attrs.map(&:first)) if builder
       end
     end
   end

--- a/spec/unit/rom/mapper/model_dsl_spec.rb
+++ b/spec/unit/rom/mapper/model_dsl_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe ROM::Mapper::ModelDSL do
+  describe '#model' do
+    it 'calls the builder with non-excluded attributes only' do
+      definition_class = Class.new do
+        include ROM::Mapper::ModelDSL
+
+        def initialize
+          @attributes = [[:name], [:title, { exclude: true }]]
+          @builder = ->(attrs) { Struct.new(*attrs) }
+        end
+      end
+      model_instance = definition_class.new.model.new
+      expect(model_instance).to respond_to(:name)
+      expect(model_instance).to_not respond_to(:title)
+    end
+  end
+end


### PR DESCRIPTION
Other than being The Right Thing™ in general, this makes rom specs not throw the ‘method redefined; discarding old name’ warning. ROSSConf :sparkling_heart: 