### PR TITLE
Allow attribute's for option to take an array.

### DIFF
--- a/lib/rom/header.rb
+++ b/lib/rom/header.rb
@@ -182,7 +182,7 @@ module ROM
     #
     # @api private
     def initialize_tuple_keys
-      @tuple_keys = mapping.keys + non_primitives.flat_map(&:tuple_keys)
+      @tuple_keys = mapping.keys.flatten + non_primitives.flat_map(&:tuple_keys)
     end
 
     # Set all tuple keys from all attributes popping from Unwrap and Ungroup

--- a/lib/rom/header/attribute.rb
+++ b/lib/rom/header/attribute.rb
@@ -93,6 +93,10 @@ module ROM
       def mapping
         { key => name }
       end
+
+      def union?
+        key.is_a? ::Array
+      end
     end
 
     # Embedded attribute is a special attribute type that has a header

--- a/spec/unit/rom/processor/transproc_spec.rb
+++ b/spec/unit/rom/processor/transproc_spec.rb
@@ -68,6 +68,29 @@ describe ROM::Processor::Transproc do
     end
   end
 
+  describe 'key from exsisting keys' do
+    let(:attributes) do
+      coercer = ->(a,b) { b + a }
+      [[:c, {from: [:a, :b], coercer: coercer} ]]
+    end
+
+    let(:relation) do
+      [
+        {a: 'works', b: 'this'}
+      ]
+    end
+
+    let (:expected_result) do
+      [
+        {c: 'thisworks'}
+      ]
+    end
+
+    it 'returns tuples a new key added based on exsiting keys' do
+      expect(transproc[relation]).to eql(expected_result)
+    end
+  end
+
   describe 'rejecting keys' do
     let(:options) { { reject_keys: true } }
 


### PR DESCRIPTION
Resolves #23. 

Example:
```ruby
data = {
  that: 'this',
  this: 'that'
}

class MyMapper < ROM::Mapper
  attribute(:that_this, from: [:that, :this]) { |v,a| "#{v} #{a}" }
end

MyMapper.build.call([data]).inspect #=> [{:that_this=>"this that"}]
```