### PR TITLE
Implement copy_keys as a DSL option

### DIFF
--- a/lib/rom/header.rb
+++ b/lib/rom/header.rb
@@ -20,6 +20,9 @@ module ROM
     attr_reader :reject_keys
 
     # @api private
+    attr_reader :copy_keys
+
+    # @api private
     attr_reader :attributes
 
     # @return [Hash] attribute key/name mapping for all primitive attributes
@@ -62,6 +65,7 @@ module ROM
     def initialize(attributes, options = {})
       @options = options
       @model = options[:model]
+      @copy_keys = options.fetch(:copy_keys, false)
       @reject_keys = options.fetch(:reject_keys, false)
 
       @attributes = attributes

--- a/lib/rom/mapper.rb
+++ b/lib/rom/mapper.rb
@@ -8,7 +8,7 @@ module ROM
     include DSL
     include Dry::Equalizer(:transformers, :header)
 
-    defines :relation, :register_as, :symbolize_keys,
+    defines :relation, :register_as, :symbolize_keys, :copy_keys,
       :prefix, :prefix_separator, :inherit_header, :reject_keys
 
     inherit_header true

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -14,7 +14,7 @@ module ROM
     class AttributeDSL
       include ModelDSL
 
-      attr_reader :attributes, :options, :symbolize_keys, :reject_keys, :steps
+      attr_reader :attributes, :options, :copy_keys, :symbolize_keys, :reject_keys, :steps
 
       # @param [Array] attributes accumulator array
       # @param [Hash] options
@@ -23,6 +23,7 @@ module ROM
       def initialize(attributes, options)
         @attributes = attributes
         @options = options
+        @copy_keys = options.fetch(:copy_keys)
         @symbolize_keys = options.fetch(:symbolize_keys)
         @prefix = options.fetch(:prefix)
         @prefix_separator = options.fetch(:prefix_separator)
@@ -344,7 +345,7 @@ module ROM
       #
       # @api private
       def header
-        Header.coerce(attributes, model: model, reject_keys: reject_keys)
+        Header.coerce(attributes, copy_keys: copy_keys, model: model, reject_keys: reject_keys)
       end
 
       private

--- a/lib/rom/mapper/dsl.rb
+++ b/lib/rom/mapper/dsl.rb
@@ -78,7 +78,8 @@ module ROM
         #
         # @api private
         def options
-          { prefix: prefix,
+          { copy_keys: copy_keys,
+            prefix: prefix,
             prefix_separator: prefix_separator,
             symbolize_keys: symbolize_keys,
             reject_keys: reject_keys }

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -353,9 +353,10 @@ module ROM
       # @api private
       def initialize_row_proc
         @row_proc = compose { |ops|
+          alias_handler = header.copy_keys ? :copy_keys : :rename_keys
           process_header_keys(ops)
 
-          ops << t(:rename_keys, mapping) if header.aliased?
+          ops << t(alias_handler, mapping) if header.aliased?
           ops << header.map { |attr| visit(attr) }
           ops << t(:constructor_inject, model) if model
         }

--- a/spec/integration/mapper_spec.rb
+++ b/spec/integration/mapper_spec.rb
@@ -17,7 +17,7 @@ describe ROM::Mapper do
       let(:mapper_body) do
         proc do
           attribute(:key) { |key| [prefix, key].join('_') }
-        
+
           def prefix
             'foo'
           end
@@ -39,7 +39,7 @@ describe ROM::Mapper do
           embedded :items, type: :hash do
             attribute(:key) { |key| [prefix, key].join('_') }
           end
-        
+
           def prefix
             'foo'
           end
@@ -61,7 +61,7 @@ describe ROM::Mapper do
           wrap :items do
             attribute(:key) { |key| [prefix, key].join('_') }
           end
-        
+
           def prefix
             'foo'
           end
@@ -83,7 +83,7 @@ describe ROM::Mapper do
           unwrap :items do
             attribute(:key) { |key| [prefix, key].join('_') }
           end
-        
+
           def prefix
             'foo'
           end

--- a/spec/integration/mapper_spec.rb
+++ b/spec/integration/mapper_spec.rb
@@ -28,6 +28,21 @@ describe ROM::Mapper do
         is_expected.to match_array(results)
       end
     end
+
+    context 'when copying aliased keys to multiple attributes' do
+      let(:tuples) { [{ key: 'bar' }] }
+      let(:results) { [{ key: 'bar', key2: 'bar', key3: 'bar' }] }
+      let(:mapper_body) do
+        proc do
+          copy_keys true
+          attribute([:key2, :key3], from: :key)
+        end
+      end
+
+      it 'creates attributes by copying keys rather than renaming' do
+        is_expected.to match_array(results)
+      end
+    end
   end
 
   describe '.embedded' do

--- a/spec/unit/rom/mapper/dsl_spec.rb
+++ b/spec/unit/rom/mapper/dsl_spec.rb
@@ -71,11 +71,23 @@ describe ROM::Mapper do
     end
   end
 
+  describe 'copy_keys' do
+    let(:attributes) { [[:name, type: :string]] }
+    let(:options) { { copy_keys: true } }
+
+    it 'sets copy_keys for the header' do
+      mapper.copy_keys true
+      mapper.attribute :name, type: :string
+
+      expect(header).to eql(expected_header)
+    end
+  end
+
   describe 'reject_keys' do
     let(:attributes) { [[:name, type: :string]] }
     let(:options) { { reject_keys: true } }
 
-    it 'sets rejected_keys for the header' do
+    it 'sets reject_keys for the header' do
       mapper.reject_keys true
       mapper.attribute :name, type: :string
 

--- a/spec/unit/rom/processor/transproc_spec.rb
+++ b/spec/unit/rom/processor/transproc_spec.rb
@@ -68,21 +68,39 @@ describe ROM::Processor::Transproc do
     end
   end
 
+  context 'copying keys' do
+    let(:options) do
+      { copy_keys: true }
+    end
+
+    let(:attributes) do
+      [['b', from: 'a'], ['c', from: 'b']]
+    end
+
+    let(:relation) do
+      [{ 'a' => 'copy' }]
+    end
+
+    it 'copies without removing the original' do
+      expect(transproc[relation]).to eql([{ 'a' => 'copy', 'b' => 'copy', 'c' => 'copy' }])
+    end
+  end
+
   describe 'key from exsisting keys' do
     let(:attributes) do
-      coercer = ->(a,b) { b + a }
-      [[:c, {from: [:a, :b], coercer: coercer} ]]
+      coercer = ->(a, b) { b + a }
+      [[:c, { from: [:a, :b], coercer: coercer }]]
     end
 
     let(:relation) do
       [
-        {a: 'works', b: 'this'}
+        { a: 'works', b: 'this' }
       ]
     end
 
-    let (:expected_result) do
+    let(:expected_result) do
       [
-        {c: 'thisworks'}
+        { c: 'thisworks' }
       ]
     end
 


### PR DESCRIPTION
`ROM::Mapper` currently does not handle the use case of declaring an attribute with the `from` option without removing the original key from the relation. This can be useful when propagating an id to a downstream model, or mutating a tuple such as `{ choices: ['foo', 'bar'] }` into `{ choice_foo: true, choice_bar: true }`.

This PR provides a macro to use Transproc's `copy_keys` transformation wherever aliases are encountered in a relation, rather than assuming `rename_keys` should be used.