### PR TITLE
Raise configuration exception if coercer block does not exist for union values in :from

### DIFF
--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -22,7 +22,7 @@ module ROM
         import ::Transproc::HashTransformations
         import ::Transproc::ClassTransformations
         import ::Transproc::ProcTransformations
-        INVALID_INJECT_UNION_VALUE = "%s attribute: block is required for :from with union value."
+        INVALID_INJECT_UNION_VALUE = "%s attribute: block is required for :from with union value.".freeze
 
         def self.identity(tuple)
           tuple

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -22,6 +22,7 @@ module ROM
         import ::Transproc::HashTransformations
         import ::Transproc::ClassTransformations
         import ::Transproc::ProcTransformations
+        INVALID_INJECT_UNION_VALUE = "%s attribute: block is required for :from with union value."
 
         def self.identity(tuple)
           tuple
@@ -32,6 +33,8 @@ module ROM
         end
 
         def self.inject_union_value(tuple, name, keys, coercer)
+          raise ROM::MapperMisconfiguredError, INVALID_INJECT_UNION_VALUE % [name] if !coercer
+
           values = tuple.values_at(*keys)
           result = coercer.call(*values)
 

--- a/spec/unit/rom/processor/transproc_spec.rb
+++ b/spec/unit/rom/processor/transproc_spec.rb
@@ -107,6 +107,11 @@ describe ROM::Processor::Transproc do
     it 'returns tuples a new key added based on exsiting keys' do
       expect(transproc[relation]).to eql(expected_result)
     end
+
+    it 'raises a configuration exception if coercer block does not exist' do
+      attributes[0][1][:coercer] = nil
+      expect { transproc[relation] }.to raise_error(ROM::MapperMisconfiguredError)
+    end
   end
 
   describe 'rejecting keys' do

--- a/spec/unit/rom/processor/transproc_spec.rb
+++ b/spec/unit/rom/processor/transproc_spec.rb
@@ -86,7 +86,7 @@ describe ROM::Processor::Transproc do
     end
   end
 
-  describe 'key from exsisting keys' do
+  describe 'key from existing keys' do
     let(:attributes) do
       coercer = ->(a, b) { b + a }
       [[:c, { from: [:a, :b], coercer: coercer }]]


### PR DESCRIPTION
This PR raises a meaningful exception for cases where a block is not passed to attributes with a union value in the "from:" parameter.  

Current behavior:
```
attribute(:v1_color_r, from: [:a, :b])

NoMethodError:
  undefined method `call' for nil:NilClass
# ./vendor/ruby/2.1.0/gems/rom-mapper-0.3.0/lib/rom/processor/transproc.rb:39:in `inject_union_value'
```

Proposed behavior:
```
attribute(:v1_color_r, from: [:a, :b])

ROM::MapperMisconfiguredError:
  v1_color_r attribute: block is required for :from with union value.
# ./vendor/ruby/2.1.0/gems/rom-mapper-0.3.0/lib/rom/processor/transproc.rb:36:in `inject_union_value'
```
