### PR TITLE
Don’t reject keys if copy_keys option is true for arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: "bundle exec rake ci"
 rvm:
   - 2.0
   - 2.1
-  - 2.2
+  - 2.2.5
   - 2.3.0
   - rbx-2
   - jruby-9000

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -131,7 +131,7 @@ module ROM
         if attribute.union?
           compose do |ops|
             ops << t(:inject_union_value, attribute.name, attribute.key, coercer)
-            ops << t(:reject_keys, attribute.key)
+            ops << t(:reject_keys, attribute.key) unless header.copy_keys
           end
         elsif coercer
           t(:map_value, attribute.name, t(:bind, mapper, coercer))

--- a/spec/unit/rom/processor/transproc_spec.rb
+++ b/spec/unit/rom/processor/transproc_spec.rb
@@ -86,7 +86,7 @@ describe ROM::Processor::Transproc do
     end
   end
 
-  describe 'key from existing keys' do
+  context 'key from existing keys' do
     let(:attributes) do
       coercer = ->(a, b) { b + a }
       [[:c, { from: [:a, :b], coercer: coercer }]]
@@ -104,6 +104,12 @@ describe ROM::Processor::Transproc do
       ]
     end
 
+    let(:copy_keys_expected_result) do
+      [
+        { a: 'works', b: 'this', c: 'thisworks'}
+      ]
+    end
+
     it 'returns tuples a new key added based on exsiting keys' do
       expect(transproc[relation]).to eql(expected_result)
     end
@@ -111,6 +117,11 @@ describe ROM::Processor::Transproc do
     it 'raises a configuration exception if coercer block does not exist' do
       attributes[0][1][:coercer] = nil
       expect { transproc[relation] }.to raise_error(ROM::MapperMisconfiguredError)
+    end
+
+    it 'honors the copy_keys option' do
+      options.merge!({ copy_keys: true })
+      expect(transproc[relation]).to eql(copy_keys_expected_result)
     end
   end
 


### PR DESCRIPTION
When copy keys is true, keys are copied and not removed from the result.  This change preserves that behavior for inject_union_value.   This is useful in preprocessor steps where other mappings use the same key.
```
attribute(:c, from: [:a, b]) do |a, b|
  b + a
end
```
Without copy keys:
```
{ a: 'works', b: 'this' } -> { c: 'thisworks' }
```

Proposed change with copy keys:
```
{ a: 'works', b: 'this' }  -> { a: 'works', b: 'this', c: 'thisworks'}
```